### PR TITLE
Fix LED gpio pinout & Disable UART for USB

### DIFF
--- a/ruuvi_board_gwnrf.h
+++ b/ruuvi_board_gwnrf.h
@@ -75,8 +75,8 @@
 
 // LED definitions
 #define RB_LEDS_NUMBER               (1U)
-#define RB_LED_1                     RB_PORT_PIN_MAP(0U, 13U)
-#define RB_LEDS_ACTIVE_STATE         { 1U }
+#define RB_LED_1                     RB_PORT_PIN_MAP(0U, 17U)
+#define RB_LEDS_ACTIVE_STATE         { 0U }
 #define RB_LEDS_LIST                 { RB_LED_1 }
 #define RB_LED_GREEN                 RB_LED_1
 #define RB_LED_ACTIVITY              RB_LED_1

--- a/ruuvi_board_pca10040.h
+++ b/ruuvi_board_pca10040.h
@@ -131,7 +131,7 @@
 #define RB_UART_USB_RX_PIN           RB_PORT_PIN_MAP(0, 8)
 #define RB_UART_USB_CTS_PIN          RB_PORT_PIN_MAP(0, 7)
 #define RB_UART_USB_RTS_PIN          RB_PORT_PIN_MAP(0, 5)
-#define RB_UART_USB_HWFC_ENABLED     1
+#define RB_UART_USB_HWFC_ENABLED     0
 #define RB_UART_USB_PARITY_ENABLED   0
 #define RB_UART_BAUDRATE_9600        0
 #define RB_UART_BAUDRATE_115200      1


### PR DESCRIPTION
- Correct LED pinout for GW A2 board.
- Disable UART/USB to use with ESP DevKit
Solves #13 